### PR TITLE
Mejora API INEGI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/build
+cities.csv

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,7 +27,20 @@
   @testset "API INEGI" begin
     token = ENV["INEGI_TOKEN"]
     @test Covid.poblacion_mexico(token).lugar == "México"
+
     @test Covid.poblacion_entidad(token, "32").lugar == "Zacatecas"
+    @test Covid.poblacion_entidad(token, "06").densidad_poblacion == 126.39943
+
     @test Covid.poblacion_municipio(token, "01", "001").lugar == "Aguascalientes, Aguascalientes"
+
+    cdmx = Covid.poblacion_municipio(token, "09", "016")
+    @test cdmx.lugar == "Ciudad de México, Miguel Hidalgo"
+    @test cdmx.hombres == 172667.00
+    @test cdmx.hombres == 172667.00
+    @test cdmx.mujeres == 200222.00
+    @test cdmx.porcentaje_hombres == 45.847179
+    @test cdmx.porcentaje_mujeres == 54.152821
+    @test cdmx.porcentaje_indigena == 5.0142822
+    @test cdmx.densidad_poblacion == 7855.6605
   end;
 end;


### PR DESCRIPTION
Calcula por país (México), entidad federativa y municipio lo siguiente.
 - nombre del lugar
 - población total
 - población hombres
 - población mujeres
 - porcentaje hombres
 - porcentaje mujeres
 - porcentaje que se considera indigena

Las respectivas pruebas y ajustes menores a .gitignore para que no
interfiera con los archivos generados por los tests.