### PR TITLE
Hacer el token INEGI un argumento opcional.

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -25,15 +25,14 @@
   end;
 
   @testset "API INEGI" begin
-    token = ENV["INEGI_TOKEN"]
-    @test Covid.poblacion_mexico(token).lugar == "México"
+    @test Covid.poblacion_mexico().lugar == "México"
 
-    @test Covid.poblacion_entidad(token, "32").lugar == "Zacatecas"
-    @test Covid.poblacion_entidad(token, "06").densidad_poblacion == 126.39943
+    @test Covid.poblacion_entidad("32").lugar == "Zacatecas"
+    @test Covid.poblacion_entidad("06").densidad_poblacion == 126.39943
 
-    @test Covid.poblacion_municipio(token, "01", "001").lugar == "Aguascalientes, Aguascalientes"
+    @test Covid.poblacion_municipio("01", "001").lugar == "Aguascalientes, Aguascalientes"
 
-    cdmx = Covid.poblacion_municipio(token, "09", "016")
+    cdmx = Covid.poblacion_municipio("09", "016")
     @test cdmx.lugar == "Ciudad de México, Miguel Hidalgo"
     @test cdmx.hombres == 172667.00
     @test cdmx.hombres == 172667.00


### PR DESCRIPTION
Se puede poner la variable de entorno que evita tener que pasar como
argumento al token cada vez que se quiera usar.