### PR TITLE
Renombra paquete, Covid -> Reporstat

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -283,9 +283,9 @@ version = "0.3.3"
 
 [[StructTypes]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "f66fdeb76151f8e6eb2d08e56e169b0915c8fff0"
+git-tree-sha1 = "65a43f5218197bc7091b76bc273a5e323a1d7b0d"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-version = "1.2.2"
+version = "1.2.3"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "Covid"
+name = "Reporstat"
 uuid = "d7c52d05-8ad2-4f52-9d74-13b6c97b52ae"
 authors = ["Bruno A. Muciño <mucinoab@gmail.com>"]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Julia-COVID
-[![codecov](https://codecov.io/gh/mucinoab/Covid/branch/master/graph/badge.svg?token=3aik50X26D)](https://codecov.io/gh/mucinoab/Covid)
+# Reporstat
+[![codecov](https://codecov.io/gh/mucinoab/Reporstat/branch/master/graph/badge.svg?token=3aik50X26D)](https://codecov.io/gh/mucinoab/Reporstat)
     <p align="center">
       <img width="578" height="374" src="https://user-images.githubusercontent.com/28630268/105275429-f62e0380-5b64-11eb-8e7b-7788053c50ce.png">
     </p>
     
-[Documentación](https://mucinoab.github.io/Covid/dev/)
+[Documentación](https://mucinoab.github.io/Reporstat/dev/)
 
 Se tiene como objetivo aprovechar la información a nivel municipal del INEGI, CONAPO y CONEVAL para consolidar en un solo lugar los datos abiertos de la Secretaría de Salud sobre COVID-19 en México, junto con información relevante del municipio de residencia de cada caso.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,16 +2,16 @@ push!(LOAD_PATH,"../src/") #eso es por si Julia no encuentra el ./src
 using Pkg
 Pkg.activate(".")
 
-using Documenter, Covid
+using Documenter, Reporstat
 
 makedocs(
-    sitename = "Covid.jl",
+    sitename = "Reporstat.jl",
     format = Documenter.HTML(),
-    modules = [Covid],
+    modules = [Reporstat],
     pages=[
            "Home" => "index.md",
           ])
 #aqui esta la informacion general de la pagina
 deploydocs(
-    repo = "github.com/mucinoab/Covid.git"
+    repo = "github.com/mucinoab/Reporstat.git"
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# Covid.jl
+# Reporstat.jl
 
 Paquete que tiene como objetivo aprovechar la información a nivel municipal del INEGI, CONAPO y CONEVAL para consolidar en un solo lugar los datos abiertos de la Secretaría de Salud sobre COVID-19 en México, junto con información relevante del municipio de residencia de cada caso.
 
@@ -12,7 +12,13 @@ Pages = ["index.md"]
 Order   = [:function]
 ```
 
-## INEGI
+## Población
+
+Datos proporcionados por el INEGI, actualizados al 2020 a excepción del
+porcentaje de población que se considera indígena, que los últimos datos 
+proporcionados son del 2015 y la extensión territorial que se calcula con 
+la densidad y población total.
+
 ```@docs
 poblacion_mexico
 poblacion_entidad
@@ -22,6 +28,10 @@ poblacion_todos_municipios
 ```
 
 ## Utilidades
+
+Utilidades varias que tienen como objetivo facilitar la manipulación de
+archivos CSV, DataFrames, entre otras.
+
 ```@docs
 data_check
 CSV_to_DataFrame

--- a/src/Filter.jl
+++ b/src/Filter.jl
@@ -194,7 +194,7 @@ end
 """
     contar_renglones(tabla::DataFrame, condiciones...)::Number
 
-Llama internamente a la función [`Covid.filtrar`](@ref Covid.filtrar) con los mismos argumentos y regresa el numero de renglones que tiene el `DataFrame` que retorna  [`Covid.filtrar`](@ref Covid.filtrar)
+Llama internamente a la función [`Reporstat.filtrar`](@ref Reporstat.filtrar) con los mismos argumentos y regresa el numero de renglones que tiene el `DataFrame` que retorna  [`Reporstat.filtrar`](@ref Reporstat.filtrar)
 # Ejemplo 
 
 ```julia-repl

--- a/src/Reporstat.jl
+++ b/src/Reporstat.jl
@@ -1,5 +1,5 @@
 push!(LOAD_PATH,"../src/")
-module Covid
+module Reporstat
 
 #include("Stats.jl") #incluimos los archivos con las funciones
 include("Utils.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 #Desde el directorio principal correr "julia --project test/runtests.jl" 
 using Test
 
-using Covid, DataFrames, CSV
+using Reporstat, DataFrames, CSV
 
 #agregar aquí el nombre del archivo donde hagan los test de su módulo
 tests = [

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,17 +1,17 @@
 @testset "Utils" begin
   @testset "sumacolumna" begin
     df = data_check("./src/cities.csv")
-    @test Covid.sumacolumna(df, 1) == 4969
-    @test Covid.sumacolumna(df, "LatD") == 4969
+    @test Reporstat.sumacolumna(df, 1) == 4969
+    @test Reporstat.sumacolumna(df, "LatD") == 4969
   end;
 
   @testset "sumafila" begin
     df = DataFrame(A = 1:4, B = 4.0:-1.0:1.0)
-    @test Covid.sumafila(df, 1) == 5.0
+    @test Reporstat.sumafila(df, 1) == 5.0
   end;
 
   @testset "data_check url" begin
-    datos_url = "https://raw.githubusercontent.com/mucinoab/Covid/master/src/cities.csv"
+    datos_url = "https://raw.githubusercontent.com/mucinoab/Reporstat/master/src/cities.csv"
     dlocal = data_check("./src/cities.csv")
     dremoto = data_check(datos_url, "URL")
     @test dlocal == dremoto
@@ -25,21 +25,20 @@
   end;
 
   @testset "API INEGI" begin
-    @test Covid.poblacion_mexico().lugar == ["México"]
+    @test Reporstat.poblacion_mexico().lugar == ["México"]
 
-    @test Covid.poblacion_entidad("32").lugar == ["Zacatecas"]
-    @test Covid.poblacion_entidad("06").densidad_poblacion == [126.39943]
+    @test Reporstat.poblacion_entidad("32").lugar == ["Zacatecas"]
+    @test Reporstat.poblacion_entidad("06").densidad_poblacion == [129.981519801061]
 
-    @test Covid.poblacion_municipio("01", "001").lugar == ["Aguascalientes, Aguascalientes"]
+    @test Reporstat.poblacion_municipio("01", "001").lugar == ["Aguascalientes, Aguascalientes"]
 
-    cdmx = Covid.poblacion_municipio("09", "016")
+    cdmx = Reporstat.poblacion_municipio("09", "016")
     @test cdmx.lugar == ["Ciudad de México, Miguel Hidalgo"]
     @test cdmx.hombres == [172667.00]
-    @test cdmx.hombres == [172667.00]
     @test cdmx.mujeres == [200222.00]
-    @test cdmx.porcentaje_hombres == [45.847179]
-    @test cdmx.porcentaje_mujeres == [54.152821]
+    @test cdmx.porcentaje_hombres == [47.1607112698145]
+    @test cdmx.porcentaje_mujeres == [52.8392887301855]
     @test cdmx.porcentaje_indigena == [5.0142822]
-    @test cdmx.densidad_poblacion == [7855.6605]
+    @test cdmx.densidad_poblacion == [8927.81062496375]
   end;
 end;


### PR DESCRIPTION
Además arregla tests que fallaban por los datos actualizados del INEGI y
añade descripciones a secciones en la documentación.