### PR TITLE
Códigos postales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ poblacion_municipios.csv
 IAIM_Entidad_2010.csv
 IAIM_Municipio.csv
 IAIM_Entidad.csv
-
+codigos_postales_municipios_2021.csv

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,6 +22,8 @@ la densidad y población total.
 ```@docs
 idh
 
+geografia
+codigos_postales
 
 poblacion_mexico
 poblacion_entidad

--- a/src/Inegi.jl
+++ b/src/Inegi.jl
@@ -4,8 +4,7 @@ include("Utilidades.jl")
 include("Constants.jl") 
 using InfoZIP, HTTP,  StringEncodings, JSON
 
-export poblacion_mexico, poblacion_entidad, poblacion_municipio, poblacion_todos_municipios, poblacion_todas_entidades, clave,idh,indicadores_pobreza_porcentaje,indicadores_pobreza, fechahoy, int_migratoria,geografia
-
+export poblacion_mexico, poblacion_entidad, poblacion_municipio, poblacion_todos_municipios, poblacion_todas_entidades, clave,idh,indicadores_pobreza_porcentaje,indicadores_pobreza, fechahoy, int_migratoria, geografia, codigos_postales
 
 #TODO nombre
 """
@@ -470,5 +469,29 @@ function geografia(cve_entidad::String,cve_municipio::String ="")::DataFrame
       error("Clave no encontrada ")
     end
   end
+end
+
+"""
+    codigos_postales()::DataFrame
+
+Proporciona todos los _códigos postales_ de México, segregados por municpio,
+en un `DataFrame`.
+Los datos son obtenidos del [Servicio Postal Mexicano.](https://www.gob.mx/correosdemexico)
+
+# Ejemplo
+
+```julia-repl
+julia> codigos_postales()
+2465×6 DataFrame
+  Row │ entidad  entidad_nombre  municipio  municipio_nombre  número de códigos postales  códigos postales
+      │ String   String          String     String            Int64                       String          
+──────┼────────────────────────────────────────────────────────────────────────────────────────────────────
+    1 │ 01       Aguascalientes  001        Aguascalientes                           599  20000;20010;20010 ⋯
+    2 │ 01       Aguascalientes  002        Asientos                                  82  20700;20700;20700 ⋯
+  ⋮   │    ⋮           ⋮             ⋮                   ⋮                ⋮                               ⋮
+```
+"""
+function codigos_postales()::DataFrame
+  return get_info("codigos_postales_municipios_2021.csv",[String,String,String,String,Int64,String])
 end
 

--- a/src/Utilidades.jl
+++ b/src/Utilidades.jl
@@ -486,7 +486,7 @@ end
 
 function get_info(path::String,tipos=[])::DataFrame
   if !isfile(path)
-    path = HTTP.download("https://raw.githubusercontent.com/mucinoab/mucinoab.github.io/dev/extras/$path")
+    path = HTTP.download("https://raw.githubusercontent.com/mucinoab/mucinoab.github.io/dev/extras/$path", pwd())
   end
   if length(tipos) > 0 
     return DataFrame(CSV.File(path,types=tipos))


### PR DESCRIPTION
Agrega función que proporciona todos los códigos postales y la
respectiva documentación.

Arregla bug mínimo en `get_info`, el comportamiento deseado es que
guarde los archivos descargados y no lo estaba haciendo, solo fue
necesario agregar el `path` a donde guardarlo para corregir esto.

Closes #44 